### PR TITLE
Remove main project node_modules only

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ heroku buildpacks:set heroku/nodejs
 Next, add the Node Cleanup buildpack to get rid of the `node_modules` directory:
 
 ```bash
-$ heroku buildpacks:set --index 1 https://github.com/leoafarias/heroku-buildpack-node-modules-cleanup
+$ heroku buildpacks:set --index 1 https://github.com/timezest/heroku-buildpack-node-modules-cleanup
 ```
 
 ## Documentation

--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# bin/compile BUILD_DIR CACHE_DIR ENV_DIR
 
 BUILD_DIR=$1
 
 echo "-----> Deleting the node_modules directory"
-find $BUILD_DIR -name 'node_modules' -type d -prune -print -exec rm -rf '{}' \;
+rm -rf "${BUILD_DIR}/node_modules"


### PR DESCRIPTION
This PR modifies the logic to remove `node_modules` in the main app directory only.